### PR TITLE
ceph-osd: fix json parser bug

### DIFF
--- a/roles/ceph-osd/tasks/main.yml
+++ b/roles/ceph-osd/tasks/main.yml
@@ -60,8 +60,8 @@
   delegate_to: "{{ groups[mon_group_name][0] }}"
   run_once: true
   until:
-    - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["num_osds"] | int > 0
-    - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["num_osds"] == (wait_for_all_osds_up.stdout | from_json)["osdmap"]["num_up_osds"]
+    - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["osdmap"]["num_osds"] | int > 0
+    - (wait_for_all_osds_up.stdout | from_json)["osdmap"]["osdmap"]["num_osds"] == (wait_for_all_osds_up.stdout | from_json)["osdmap"]["osdmap"]["num_up_osds"]
 
 - name: include crush_rules.yml
   include_tasks: crush_rules.yml


### PR DESCRIPTION
Taskname: wait for all osd to be up
Fix json parser bug for 'ceph -s -f json'
Add an 'osdmap' level after 'osdmap'

Fix: https://tracker.ceph.com/issues/43430

Signed-off-by: Dai zhiwei daizhiwei3@huawei.com